### PR TITLE
holochain version info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ GITHUB_ORGS_ALL_REPOS="holochain holo-host"
 PUBLIC_REPOS_GITHUB_ACCESS_TOKEN="<YOUR GITHUB ACCESS TOKEN HERE>"
 MAX_REPOS=100                # defaults to unlimited
 MAX_DAYS_SINCE_LAST_PUSH=180 # defaults to unlimited
+UPDATE_EXISTING_REPOS="true" # defaults to true, can be set to false in development for speed

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.env
-.DS_Store
 /.svelte-kit/
+/build/
 /node_modules/
 /package/
+/repos/
 /tmp/
-/build/

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dayjs": "^1.10.6",
     "lodash": "^4.17.21",
     "octokit": "^1.1.0",
+    "shelljs": "^0.8.4",
     "svelte-table": "^0.1.17"
   },
   "devDependencies": {

--- a/src/lib/assert.ts
+++ b/src/lib/assert.ts
@@ -21,3 +21,10 @@ export function assertExists(value: any, message?: string): void {
     )
   }
 }
+
+export function assertPresent(value: string, message?: string): void {
+  assertExists(value, message)
+  if (value === '') {
+    throw new Error('Assertion Error: value was empty string' + (message ? ` [ ${message} ]` : ''))
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,12 +13,18 @@ export const GITHUB_ORGS_ALL_REPOS = process.env['GITHUB_ORGS_ALL_REPOS']?.trim(
   ? process.env['GITHUB_ORGS_ALL_REPOS'].trim().split(/\s+/)
   : []
 
-export const MAX_REPOS = process.env['MAX_REPOS'] == null ? null : integer(process.env['MAX_REPOS'])
+export const MAX_REPOS =
+  process.env['MAX_REPOS'] == null ? Infinity : integer(process.env['MAX_REPOS'])
 
 export const MAX_DAYS_SINCE_LAST_PUSH =
   process.env['MAX_DAYS_SINCE_LAST_PUSH'] == null
-    ? null
+    ? 1_000_000 // practical infinity
     : integer(process.env['MAX_DAYS_SINCE_LAST_PUSH'])
+
+export const UPDATE_EXISTING_REPOS =
+  process.env['UPDATE_EXISTING_REPOS'] == null
+    ? true
+    : process.env['UPDATE_EXISTING_REPOS'].toLowerCase() === 'true'
 
 // pedantically ensure that string contains only an integer
 function integer(value: string) {

--- a/src/lib/run.ts
+++ b/src/lib/run.ts
@@ -1,0 +1,53 @@
+// Originally decaffeinated from:
+// https://github.com/harlantwood/lightsaber/blob/64a824c34f6b1bc7e745f62526fcafb103837368/src/shell.coffee
+
+import chalk from 'chalk'
+
+import lodash from 'lodash'
+const { clone, defaults, merge, isEmpty } = lodash
+
+import shelljs from 'shelljs'
+const { exec, exit } = shelljs
+
+type Options = {
+  color?: boolean
+  relaxed?: boolean
+  quiet?: boolean
+  quietCommand?: boolean
+  quietResponse?: boolean
+}
+
+export function run(command: string, options: Options = {}): string {
+  const originalOptions = clone(options)
+  defaults(options, {
+    color: true,
+    relaxed: false,
+    quiet: false,
+    quietCommand: options.quiet != null ? options.quiet : false,
+    quietResponse: options.quiet != null ? options.quiet : false,
+  })
+
+  command = command.replace(/\s+/g, ' ')
+
+  if (!options.quietCommand) {
+    let prettyCommand = `\n==> ${command}   ${
+      isEmpty(originalOptions) ? '' : '# ' + JSON.stringify(originalOptions)
+    }`
+    if (options.color) {
+      prettyCommand = chalk.green(prettyCommand)
+    }
+    // eslint-disable-next-line no-console
+    console.log(prettyCommand)
+  }
+
+  const result = exec(command, merge(options, { silent: options.quietResponse }))
+
+  const exitCode = result.code
+  if (exitCode != null && exitCode !== 0 && !options.relaxed) {
+    // eslint-disable-next-line no-console
+    console.error(`COMMAND FAILED: ${JSON.stringify({ exitCode })}`)
+    exit(exitCode)
+  }
+
+  return result
+}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -88,6 +88,22 @@
       },
       sortable: true,
     },
+    {
+      key: 'hc_version',
+      title: 'Holochain Version',
+      value: (repo) => repo.nix_holochain_version_date || '',
+      renderValue: (repo) => {
+        if (!repo.nix_holochain_version) return ''
+        const howLongAgo = dayjs(repo.nix_holochain_version_date).fromNow()
+        const commitUrl = `https://github.com/holochain/holochain/commit/${repo.nix_holochain_version}`
+        const shortHash = repo.nix_holochain_version.slice(0, 7)
+        return (
+          `<span title="${repo.pushed_at}">${howLongAgo}</span> ` +
+          `<a href="${commitUrl}">(${shortHash})</a>`
+        )
+      },
+      sortable: true,
+    },
   ]
 </script>
 

--- a/src/routes/repos.json.ts
+++ b/src/routes/repos.json.ts
@@ -1,73 +1,172 @@
 import { Octokit } from 'octokit'
 import dayjs from 'dayjs'
+import { readFileSync, existsSync } from 'fs'
+import Promise from 'bluebird'
 
-import { assertEqual, assertExists } from '$lib/assert'
+import { run } from '$lib/run'
+import { assertEqual, assertExists, assertPresent } from '$lib/assert'
 import {
   GITHUB_ACCESS_TOKEN,
   GITHUB_ORGS_ALL_REPOS,
   MAX_DAYS_SINCE_LAST_PUSH,
   MAX_REPOS,
+  UPDATE_EXISTING_REPOS,
 } from '$lib/env'
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export async function get(): Promise<{ body: { repos: Array<object> } }> {
-  const octokit = new Octokit({ auth: GITHUB_ACCESS_TOKEN })
+const REPOS_DIR = `${process.cwd()}/repos`
+const HOLOCHAIN_REPO_NAME = `holochain/holochain`
+const OCTOKIT = new Octokit({ auth: GITHUB_ACCESS_TOKEN })
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export async function get(): Promise<{ body: { repos: Array<RepoForUi> } }> {
+  let repos
+  repos = await fetchRepos()
+  repos = sortRepos(repos)
+  repos = filterRepos(repos)
+  repos = await addWorkflows(repos)
+  repos = await addHolochainVersionDataToRepos(repos)
+  repos = fieldsForUi(repos)
+  return { body: { repos } }
+}
+
+async function fetchRepos() {
   const repoListPromises = GITHUB_ORGS_ALL_REPOS.map((githubOrg) => {
-    return octokit.rest.repos.listForOrg({
+    return OCTOKIT.rest.repos.listForOrg({
       org: githubOrg,
       sort: 'pushed',
-      per_page: MAX_REPOS || 100,
+      per_page: MAX_REPOS,
     })
   })
 
   const repoListResponses = await Promise.all(repoListPromises)
   // .catch(console.error)
   const repoLists = repoListResponses.map((response) => response.data)
-  let repos = repoLists.flat() // `flat()` only flattens first level of nesting
+  const repos = repoLists.flat()
+  return repos
+}
 
-  repos.sort((a, b) => {
+function sortRepos(repos) {
+  return repos.sort((a, b) => {
     if (a.pushed_at == null)
       throw new Error(
         `One or more repos are missing .pushed_at field: ${JSON.stringify({ repos })}`
       )
     return a.pushed_at > b.pushed_at ? -1 : 1
   })
+}
 
-  if (MAX_REPOS != null) {
-    repos = repos.slice(0, MAX_REPOS)
-  }
+function filterRepos(repos) {
+  repos = repos.slice(0, MAX_REPOS)
 
-  if (MAX_DAYS_SINCE_LAST_PUSH != null) {
-    const now = dayjs()
-    const oldest = now.subtract(MAX_DAYS_SINCE_LAST_PUSH, 'day')
-    repos = repos.filter((repo) => {
-      return dayjs(repo.pushed_at) > oldest
-    })
-  }
+  const now = dayjs()
+  const oldest = now.subtract(MAX_DAYS_SINCE_LAST_PUSH, 'day')
+  repos = repos.filter((repo) => {
+    return dayjs(repo.pushed_at) > oldest
+  })
+  return repos
+}
 
+async function addWorkflows(repos) {
   const workflowPromises = repos.map((repo) => {
     assertExists(repo.owner)
-    return octokit.rest.actions.listRepoWorkflows({ owner: repo.owner.login, repo: repo.name })
+    return OCTOKIT.rest.actions.listRepoWorkflows({ owner: repo.owner.login, repo: repo.name })
   })
   const workflows = await Promise.all(workflowPromises)
   // .catch(console.error)
-
   assertEqual(repos.length, workflows.length)
 
   for (let i = 0; i < repos.length; i++) {
     repos[i].workflows = workflows[i].data.workflows
   }
+  return repos
+}
 
-  // trim down to the fields needed by interface
+async function addHolochainVersionDataToRepos(repos) {
+  cloneOrUpdateLocalCopyByName(HOLOCHAIN_REPO_NAME, { updateExistingRepo: true })
+  repos = await Promise.map(
+    repos,
+    (repo) => {
+      cloneOrUpdateLocalCopy(repo)
+      repo = addHolochainVersionData(repo)
+      return repo
+    },
+    { concurrency: 5 }
+  )
+  return repos
+}
+
+function cloneOrUpdateLocalCopy(repo): void {
+  assertPresent(repo.full_name)
+  cloneOrUpdateLocalCopyByName(repo.full_name)
+}
+
+function cloneOrUpdateLocalCopyByName(
+  repoFullName: string,
+  options = { updateExistingRepo: false }
+): void {
+  const repoDir = `${REPOS_DIR}/${repoFullName}`
+  if (existsSync(`${repoDir}/.git/`)) {
+    if (UPDATE_EXISTING_REPOS === true || options.updateExistingRepo === true) {
+      run(`cd ${repoDir} && git fetch`)
+      run(`cd ${repoDir} && git reset FETCH_HEAD --hard`)
+      run(`cd ${repoDir} && git clean -fd`)
+    }
+  } else {
+    run(`git clone https://github.com/${repoFullName}.git ${repoDir}`)
+  }
+}
+
+function addHolochainVersionData(repo) {
+  const NIX_HC_VERSION_PATTERN =
+    /holochainVersion\s*=\s*{\s*rev\s*=\s*"(?<holochainVersion>[0-9a-f]{40})"/
+  const repoDir = `${REPOS_DIR}/${repo.full_name}`
+  const nixPath = `${repoDir}/default.nix`
+  if (existsSync(nixPath)) {
+    const nixConfig = readFileSync(nixPath).toString()
+    const match = NIX_HC_VERSION_PATTERN.exec(nixConfig)
+    const holochainVersion = match?.groups?.holochainVersion
+    if (holochainVersion) {
+      repo.nix_holochain_version = holochainVersion
+      repo.nix_holochain_version_date = getholochainVersionDate(holochainVersion)
+    }
+  }
+  return repo
+}
+
+function getholochainVersionDate(holochainVersion) {
+  const STRICT_ISO_8601_DATE = '%cI'
+  return run(
+    `cd ${REPOS_DIR}/${HOLOCHAIN_REPO_NAME} && ` +
+      `git show --no-patch --no-notes --pretty='${STRICT_ISO_8601_DATE}' ${holochainVersion}`
+  ).trim()
+}
+
+type RepoForUi = {
+  default_branch: string
+  full_name: string
+  nix_holochain_version: string
+  nix_holochain_version_date: string
+  pushed_at: string
+  workflows: string
+}
+
+// trim down to the fields needed by interface
+function fieldsForUi(repos): Array<RepoForUi> {
   repos = repos.map((repo) => {
+    const workflowData = repo.workflows.map((workflow) => {
+      return {
+        badge_url: workflow.badge_url,
+        path: workflow.path,
+      }
+    })
     return {
       default_branch: repo.default_branch,
       full_name: repo.full_name,
+      nix_holochain_version: repo.nix_holochain_version,
+      nix_holochain_version_date: repo.nix_holochain_version_date,
       pushed_at: repo.pushed_at,
-      workflows: repo.workflows,
+      workflows: workflowData,
     }
   })
-
-  return { body: { repos } }
+  return repos
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,7 +1160,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.3, glob@^7.1.3, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.3, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -1313,6 +1313,11 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -1796,6 +1801,13 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 regexpp@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -1821,7 +1833,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -1900,6 +1912,15 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shelljs@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Adds holochain versions, partially fulfilling #16 -- default.nix strategy only in this PR.

We clone all repos locally, then parse their `default.nix` to get the holochain version.

We display the holochain version as a relative timestamp and a short git hash.  User can sort by this column.

Screenshot: 

![Screen Shot 2021-07-17 at 1 00 29 AM](https://user-images.githubusercontent.com/38769/126629309-0d0b1bed-4f0a-4869-94f4-4247f1a013e9.png)
